### PR TITLE
Got Docker-based build and test working

### DIFF
--- a/Dockerfile.run
+++ b/Dockerfile.run
@@ -1,0 +1,8 @@
+ARG BASE
+FROM $BASE
+
+# Ideally, we'd strip out stuff needed only for building, not runtime
+
+ENTRYPOINT ["/app/bin/limbo"]
+
+# vim: set expandtab tabstop=4 shiftwidth=4 autoindent smartindent:

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,26 @@
+FROM 1science/alpine
+
+ENV PATH /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+# get our basic-needs sorted
+RUN echo http://dl-cdn.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories
+RUN apk update
+RUN apk add python3 python3-dev vim bash    \
+                curl      \
+    && curl "https://bootstrap.pypa.io/get-pip.py" | python3 \
+    && pip install --upgrade pip setuptools     \
+    && ln -s /usr/bin/python3 /usr/bin/python   \
+    && mkdir -p /opt /app
+RUN apk add gcc musl-dev libffi-dev openssl-dev
+
+ADD . /app
+WORKDIR /app
+
+# Commands from "make install"
+RUN pip install -r requirements.txt
+RUN python3 setup.py install
+RUN rm -rf build dist limbo.egg-info
+
+CMD pytest --cov=limbo --cov-report term-missing test
+
+# vim: set expandtab tabstop=4 shiftwidth=4 autoindent smartindent:

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -5,12 +5,12 @@ ENV PATH /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 # get our basic-needs sorted
 RUN echo http://dl-cdn.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories
 RUN apk update
-RUN apk add python3 python3-dev vim bash    \
-                curl      \
-    && curl "https://bootstrap.pypa.io/get-pip.py" | python3 \
-    && pip install --upgrade pip setuptools     \
+RUN apk add python3 python3-dev py-pip vim bash curl \
     && ln -s /usr/bin/python3 /usr/bin/python   \
     && mkdir -p /opt /app
+#    && curl "https://bootstrap.pypa.io/get-pip.py" | python3 \
+#    && pip install --upgrade pip setuptools     \
+
 RUN apk add gcc musl-dev libffi-dev openssl-dev
 
 ADD . /app

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -5,11 +5,10 @@ ENV PATH /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 # get our basic-needs sorted
 RUN echo http://dl-cdn.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories
 RUN apk update
-RUN apk add python3 python3-dev py-pip vim bash curl \
-    && ln -s /usr/bin/python3 /usr/bin/python   \
+RUN apk add python3 python3-dev vim bash curl \
+    && ln -s /usr/bin/python3 /usr/bin/python \
+    && /usr/bin/pip3.5 install --upgrade pip \
     && mkdir -p /opt /app
-#    && curl "https://bootstrap.pypa.io/get-pip.py" | python3 \
-#    && pip install --upgrade pip setuptools     \
 
 RUN apk add gcc musl-dev libffi-dev openssl-dev
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-NAMESPACE=llimllib
+NAMESPACE=tim77
 APP=limbo
 
 .PHONY: testall
@@ -42,17 +42,19 @@ publish:
 flake8:
 	flake8 limbo test
 
-NAMESPACE=petergrace
-APP=limbo
-
 .PHONY: docker_build
 docker_build:
-	docker build -f Dockerfile.dev -t ${NAMESPACE}/${APP} .
+	docker build -f Dockerfile.test -t ${NAMESPACE}/${APP}-test .
+	docker build --build-arg BASE=${NAMESPACE}/${APP}-test -f Dockerfile.run -t ${NAMESPACE}/${APP} .
+
+.PHONY: docker_test
+docker_test:
+	docker run -e LANG=en_US.UTF-8 ${NAMESPACE}/${APP}-test
 
 .PHONY: docker_run
 docker_run:
 	docker run -d -e SLACK_TOKEN=${SLACK_TOKEN} ${NAMESPACE}/${APP}
 
 .PHONY: docker_stop
-docker_clean:
-	docker stop $(docker ps -a -q  --filter ancestor=petergrace/limbo --format="{{.ID}}")
+docker_stop:
+	docker stop `docker ps -q --filter ancestor=${NAMESPACE}/${APP} --format="{{.ID}}"`


### PR DESCRIPTION
Resolves #3 

Note: you might want to look at the changes to  Makefile first, and also read the following explanation, before looking  at the new Dockerfiles that are being committed:

Based on conversations with Adam, the approach taken here is to use  Docker for building and testing our Chatbot, as well as deployment.  He  and I discussed the fact that this approach would tend to make the  Docker images used at runtime bigger than needed, because they contain  the test-time dependencies and test scripts.  Adam said a pattern he's  seen to deal with this is to build a Docker image for testing that has  everything needed for testing, then use that as the base for another  Dockerfile that strips out everything not needed at run time.  A nice  thing about this pattern is that the "CMD" of the test Docker image can  be to run the test suite, while the "CMD" of the runtime Docker image is  to start the service.

I've followed Adam's pattern in this commit: Dockerfile.test is the  Dockerfile for the test image, while Dockerfile.run is for the runtime  image.  I have not, however, taken the time lighten-up the runtime image.