### PR TITLE
Change Dockerfile.test to better utilize Docker build cache.

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -11,20 +11,21 @@ ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en  
 ENV LC_ALL en_US.UTF-8
 
-RUN apt-get -y install python3 python3-pip python3-dev \
-    && ln -s /usr/bin/pip3 /usr/bin/pip \
-    && ln -s /usr/bin/python3 /usr/bin/python \
-    && pip install --upgrade pip setuptools \
-    && mkdir -p /opt /app
-
 RUN apt-get -y install gcc libffi-dev libssl-dev 
+RUN apt-get -y install python3 python3-pip python3-dev
+RUN ln -s /usr/bin/pip3 /usr/bin/pip
+RUN ln -s /usr/bin/python3 /usr/bin/python
+RUN pip install --upgrade pip setuptools
 
-ADD . /app
+RUN mkdir -p /opt /app
 WORKDIR /app
 
-# Commands from "make install"
+ADD requirements.txt /app
 RUN pip install -r requirements.txt
+
+ADD . /app
 RUN python3 setup.py install
+
 RUN rm -rf build dist limbo.egg-info
 
 CMD pytest --cov=limbo --cov-report term-missing test


### PR DESCRIPTION
The main improvement: The Docker command
```
RUN pip install -r requirements.txt 
```
was being run after every change to source code, because it was preceded by "`ADD .`".  This `pip install` command takes a long time (and downloads lots of stuff), so it'd be beneficial to more effectively cache its results in the Docker build cache.

In this commit, we precede the `pip install` command with `ADD requirements.txt`, which means it will only be re-run when `requirements.txt` is changed, not when any file is changed.  Otherwise the cached result is used.

In this commit we also broke up the string of `&&` separated commands into separate `RUN` commands.  This is more idiomatic and is also more cache friendly (since the result of each `RUN` command is a separate item in the build cache).