### PR TITLE
Add "update-only" command to "deploy.sh" and change .travis.yml to use it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,12 +65,13 @@ ecr_repo:
 	   aws ecr create-repository --region us-east-1 --repository-name tim77/${BOTNAME}
 
 .PHONY: travis_deploy
-travis_deploy: ecs_deploy_and_run
+travis_deploy:
+	bin/deploy.sh update
 
-.PHONY: ecs_deploy_and_run
-ecs_deploy_and_run:
-	bin/deploy.sh up
+.PHONY: ecs_start
+ecs_start:
+	bin/deploy.sh start
 
 .PHONY: ecs_stop
 ecs_stop:
-	bin/deploy.sh down
+	bin/deploy.sh stop

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -14,8 +14,8 @@
 # or WIP_SLACK_TOKEN must be defined (based on whether this is master
 # or WIP deploy).
 
-if [ $# -ne 1 ] || ([ "$1" != "up" ] && [ "$1" != "down" ]); then
-  echo "Usage: $0 up|down"
+if [ $# -ne 1 ]; then
+  echo "Usage: $0 start|stop|update"
   exit 1
 fi
 
@@ -52,15 +52,33 @@ fi
 
 export IMAGE_THIS_BUILD=560921689673.dkr.ecr.us-east-1.amazonaws.com/tim77/$BOTNAME:$TYPE
 
-if [ "$1" = "up" ]; then
-  bin/ecr_push.sh
-  # Note: the following reads docker-compose.yml for deployment instructions
-  docker-compose --file cmds.yml run \
-    ecs-cli compose --file docker-compose.yml --region us-east-1 --cluster limbo \
-      --project-name $BOTNAME-$TYPE service up
-else
-  # Note: the following reads docker-compose.yml for deployment instructions
-  docker-compose --file cmds.yml run \
-    ecs-cli compose --file docker-compose.yml --region us-east-1 --cluster limbo \
-      --project-name $BOTNAME-$TYPE service rm
-fi
+case "$1" in
+  start)
+    bin/ecr_push.sh
+    docker-compose --file cmds.yml run \
+      ecs-cli compose --file docker-compose.yml --region us-east-1 --cluster limbo \
+        --project-name $BOTNAME-$TYPE service up
+    ;;
+
+  stop)
+    docker-compose --file cmds.yml run \
+      ecs-cli compose --file docker-compose.yml --region us-east-1 --cluster limbo \
+        --project-name $BOTNAME-$TYPE service rm
+    ;;
+
+  update)
+    if (docker-compose --file cmds.yml run ecs-cli ps --region us-east-1 --cluster limbo \
+         | grep RUNNING | grep $BOTNAME); then
+      bin/ecr_push.sh
+      docker-compose --file cmds.yml run \
+        ecs-cli compose --file docker-compose.yml --region us-east-1 --cluster limbo \
+          --project-name $BOTNAME-$TYPE service up
+    else
+      echo "Service not running, so not pushing an update."
+    fi
+    ;;
+
+  *)
+    echo "Usage: $0 start|update|stop"
+    exit 1
+esac


### PR DESCRIPTION
Closes #15.

Changed deploy.sh to have subcommands "start", "stop", and "update". The "update" subcommand will update a service if it's running, but will not start the service if it's not runnings. In this pull, .travis.yml is changed to use this new "update" subcommand, which means Travis will not start a bot that's not already started. (Implication: an operator needs to manually start a bot, which they can do using "make ecs_start".)

For evidence that this works, see [Build 77](https://travis-ci.org/tim77code/limbo/builds/313014048) (pushed to running instance) and [Build 78](https://travis-ci.org/tim77code/limbo/builds/313018529) (didn't push because not running).