### PR TITLE
Add memory reservation for capacity-planning exercise

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       LIMBO_CLOUDWATCH:
       SLACK_TOKEN:
     image: $IMAGE_THIS_BUILD
+    mem_reservation: 980m
     logging:
       driver: awslogs
       options:


### PR DESCRIPTION
I found that putting an explicit memory reservation into the task-definition makes reservation process more predictable.  I put in a relatively high reservation to ensure that we'll experience a failure during class.
