### PR TITLE
Better LIMBO_NEEDMENTION feature flag

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+LIMBO_NEEDMENTION=false
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-.env
 venv/
 *.pyc
 config.py

--- a/cmds.yml
+++ b/cmds.yml
@@ -16,7 +16,7 @@ services:
       AWS_SECRET_ACCESS_KEY:
       IMAGE_THIS_BUILD:
       SLACK_TOKEN:
-      LIMBO_NEEDMENTION: 'true'
+      LIMBO_NEEDMENTION:
       LIMBO_CLOUDWATCH:
       BOTNAME:
     image: tim77/limbo-test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     environment:
       AWS_ACCESS_KEY_ID:
       AWS_SECRET_ACCESS_KEY:
-      LIMBO_NEEDMENTION: 'false'
+      LIMBO_NEEDMENTION:
       LIMBO_CLOUDWATCH:
       SLACK_TOKEN:
     image: $IMAGE_THIS_BUILD

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     environment:
       AWS_ACCESS_KEY_ID:
       AWS_SECRET_ACCESS_KEY:
-      LIMBO_NEEDMENTION: 'true'
+      LIMBO_NEEDMENTION: 'false'
       LIMBO_CLOUDWATCH:
       SLACK_TOKEN:
     image: $IMAGE_THIS_BUILD

--- a/limbo/limbo.py
+++ b/limbo/limbo.py
@@ -137,7 +137,7 @@ def handle_message(event, server):
         return
 
     # skip messages that don't include our username 
-    if server.config.get("needmention"):
+    if server.config.get("needmention") == "true":
         text = event.get("text", "")
         # TODO: make sure server.slack.userid is RE-safe
         match = re.search("<@{}>".format(server.slack.userid), text)


### PR DESCRIPTION
To turn this into a true feature-flag, it must be possible to toggle its value without rebuilding the docker image.  Further, we want the feature _off_ by default, which makes for a better exercise for the students.

This commit achieves this goal:

1) We used the docker-compose `.env`-file feature to inject a default but overridable value of "false" into the containers environment.  As far as I can tell, `.env` files are the only way to set defaults for environment variables.  (`.env` was listed in the upstream's `.gitignore` file, so we removed it from there.)

2) We took out the hard-coded settings of this variable in `cmds.yml` and `docker-compose.yml`.  If a value is set in the environment when `docker-compose` is executed, then that value will get used.  Otherwise, the value in the `.env` file will be used.

3) We now test that `LIMBO_NEEDMENTION` is set specifically to `true` before enabling this feature.  In the past, we simply tested for the presence of `LIMBO_NEEDMENTION` in the environment, an approach that doesn't work if we want to have a default value provided by `.env`.