### PR TITLE
 enable plugin calls reinit_plugins directly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-export BOTNAME := limbo-travisci
+export BOTNAME := limbo-chaiken
 
 .PHONY: testall
 testall: requirements

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-export BOTNAME := limbo-chaiken
+export BOTNAME := limbo-travisci
 
 .PHONY: testall
 testall: requirements

--- a/limbo/limbo.py
+++ b/limbo/limbo.py
@@ -99,7 +99,7 @@ def init_plugins(plugindir, plugins_to_load=None):
     sys.path = oldpath
     return hooks
 
-def reinit_plugins(plugins_to_load, msg, server):
+def reinit_plugins(plugins_to_load, server):
     logger.info("reinit_plugins: {0}".format(plugins_to_load))
     server.hooks = init_plugins(server.hooks['plugindir'], plugins_to_load)
 
@@ -108,13 +108,8 @@ def run_hook(hooks, hook, *args):
     for hook in hooks.get(hook, []):
         try:
             h = hook(*args)
-            if type(h) is str:
-                responses.append(h) # this is the normal case
-            elif type(h) is list:
-                logger.debug("checking hook list response: {0}".format(h[0]))
-                if h[0] == 'reinit_plugins':
-                    responses.append(h[2]) # h[2] is the string response
-                    reinit_plugins(h[1], *args) # h[1] is an array of plugins to load
+            if h:
+                responses.append(h)
         except:
             logger.warning("Failed to run plugin {0}, module not loaded".format(hook))
             logger.warning("{0}".format(sys.exc_info()[0]))

--- a/limbo/plugins/enable.py
+++ b/limbo/plugins/enable.py
@@ -5,6 +5,7 @@
 # in MIT 6.S188.
 
 import re
+from limbo.limbo import reinit_plugins
 
 def on_message(msg, server):
     text = msg.get("text", "")
@@ -15,10 +16,11 @@ def on_message(msg, server):
     plugins = match[0].strip()
     if plugins == '*':
         plugins_to_load = None # load all plugins
+        response = "enabling all plugins"
     else:
         plugins_to_load = plugins.replace(' ', ',').replace(';',',').split(',')
-    return ['reinit_plugins',
-            plugins_to_load,
-            "enabling plugins: {0}".format(plugins)]
+        response = "enabling plugins: {0}".format(plugins)
+    reinit_plugins(plugins_to_load, server)
+    return response
 
 on_bot_message = on_message

--- a/test/test_plugins/test_enable.py
+++ b/test/test_plugins/test_enable.py
@@ -1,16 +1,27 @@
 # -*- coding: UTF-8 -*-
 import os
 import sys
+import mock
+import unittest
 
 DIR = os.path.dirname(os.path.realpath(__file__))
 sys.path.insert(0, os.path.join(DIR, '../../limbo/plugins'))
 
 from enable import on_message
-import limbo
+from enable import reinit_plugins
 
-def test_basic():
-    ret = on_message({"text": u"!enable help,enable"}, None)
-    assert ret == ['reinit_plugins',
-                   ['help', 'enable'],
-                   "enabling plugins: help,enable"]
+class EnableTest(unittest.TestCase):
 
+    @mock.patch('enable.reinit_plugins')
+    def test_basic(self, reinit_plugins_mock):
+        server = 'fake_server'
+        ret = on_message({"text": u"!enable help,enable"}, server)
+        assert ret == "enabling plugins: help,enable"
+        reinit_plugins_mock.assert_called_with(['help','enable'], server)
+
+    @mock.patch('enable.reinit_plugins')
+    def test_star(self, reinit_plugins_mock):
+        server = 'fake_server'
+        ret = on_message({"text": u"!enable *"}, server)
+        assert ret == "enabling all plugins"
+        reinit_plugins_mock.assert_called_with(None, server)


### PR DESCRIPTION
Fixes the issue raised by @rstata in #31.  The enable plugin now calls reinit_plugins directly, in order to minimize potential conflicts with upstream changes.
