### PR TITLE
Allow override of BOTNAME with env variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-export BOTNAME := limbo-travisci
+export BOTNAME ?= limbo-travisci
 
 .PHONY: testall
 testall: requirements


### PR DESCRIPTION
Use gnumake's '?=' operator so you can override BOTNAME with an environment variable.

Note that I've already changed the build-instructions wiki page to conform to this pull request.