### PR TITLE
enable plugin with minimal change to upstream

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-export BOTNAME := limbo-travisci
+export BOTNAME := limbo-chaiken
 
 .PHONY: testall
 testall: requirements

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-export BOTNAME := limbo-chaiken
+export BOTNAME ?= limbo-travisci
 
 .PHONY: testall
 testall: requirements

--- a/limbo/limbo.py
+++ b/limbo/limbo.py
@@ -63,9 +63,7 @@ def init_plugins(plugindir, plugins_to_load=None):
         except OSError:
             raise InvalidPluginDir(plugindir)
 
-    # Remember the plugin directory for reinit_plugins.
-    # This extra entry in hooks increases the number of expected hooks in test_limbo.py.
-    hooks = {'plugindir': plugindir}
+    hooks = {}
 
     oldpath = copy.deepcopy(sys.path)
     sys.path.insert(0, plugindir)
@@ -98,10 +96,6 @@ def init_plugins(plugindir, plugins_to_load=None):
 
     sys.path = oldpath
     return hooks
-
-def reinit_plugins(plugins_to_load, server):
-    logger.info("reinit_plugins: {0}".format(plugins_to_load))
-    server.hooks = init_plugins(server.hooks['plugindir'], plugins_to_load)
 
 def run_hook(hooks, hook, *args):
     responses = []
@@ -272,6 +266,7 @@ def init_server(args, config, Server=LimboServer, Client=SlackClient):
 
     config_plugins = config.get("plugins")
     plugins_to_load = config_plugins.split(",") if config_plugins else []
+    config['pluginpath'] = args.pluginpath
 
     hooks = init_plugins(args.pluginpath, plugins_to_load)
     try:

--- a/limbo/plugins/enable.py
+++ b/limbo/plugins/enable.py
@@ -4,8 +4,11 @@
 # Note: This plugin implements a couple of antipatterns to be discussed
 # in MIT 6.S188.
 
+import logging
 import re
-from limbo.limbo import reinit_plugins
+from limbo.limbo import init_plugins
+
+logger = logging.getLogger(__name__)
 
 def on_message(msg, server):
     text = msg.get("text", "")
@@ -20,7 +23,9 @@ def on_message(msg, server):
     else:
         plugins_to_load = plugins.replace(' ', ',').replace(';',',').split(',')
         response = "enabling plugins: {0}".format(plugins)
-    reinit_plugins(plugins_to_load, server)
+
+    logger.info("init_plugins: {0}".format(plugins_to_load))
+    server.hooks = init_plugins(server.config.get('pluginpath'), plugins_to_load)
     return response
 
 on_bot_message = on_message

--- a/test/test_limbo.py
+++ b/test/test_limbo.py
@@ -26,7 +26,7 @@ os.environ["LIMBO_LOGFILE"] = "/tmp/deleteme"
 
 def test_plugin_success():
     hooks = limbo.init_plugins("test/plugins")
-    assert len(hooks) == 10
+    assert len(hooks) == 9
     assert "message" in hooks
     assert isinstance(hooks, dict)
     assert isinstance(hooks["message"], list)
@@ -34,7 +34,7 @@ def test_plugin_success():
 
 def test_config_plugin_none_success():
     hooks = limbo.init_plugins("test/plugins", None)
-    assert len(hooks) == 10
+    assert len(hooks) == 9
     assert "message" in hooks
     assert isinstance(hooks, dict)
     assert isinstance(hooks["message"], list)
@@ -42,7 +42,7 @@ def test_config_plugin_none_success():
 
 def test_config_plugin_empty_string_success():
     hooks = limbo.init_plugins("test/plugins", "")
-    assert len(hooks) == 10
+    assert len(hooks) == 9
     assert "message" in hooks
     assert isinstance(hooks, dict)
     assert isinstance(hooks["message"], list)
@@ -50,7 +50,7 @@ def test_config_plugin_empty_string_success():
 
 def test_config_plugin_success():
     hooks = limbo.init_plugins("test/plugins", "echo,loop")
-    assert len(hooks) == 6
+    assert len(hooks) == 5
     assert "message" in hooks
     assert isinstance(hooks, dict)
     assert isinstance(hooks["message"], list)
@@ -58,7 +58,7 @@ def test_config_plugin_success():
 
 def test_config_plugin_doesnt_exist():
     hooks = limbo.init_plugins("test/plugins", "doesnotexist")
-    assert len(hooks) == 1
+    assert len(hooks) == 0
 
 def test_plugin_invalid_dir():
     try:

--- a/test/test_plugins/test_enable.py
+++ b/test/test_plugins/test_enable.py
@@ -3,25 +3,30 @@ import os
 import sys
 import mock
 import unittest
+from mock import Mock
 
 DIR = os.path.dirname(os.path.realpath(__file__))
 sys.path.insert(0, os.path.join(DIR, '../../limbo/plugins'))
 
 from enable import on_message
-from enable import reinit_plugins
+from enable import init_plugins
 
 class EnableTest(unittest.TestCase):
 
-    @mock.patch('enable.reinit_plugins')
-    def test_basic(self, reinit_plugins_mock):
-        server = 'fake_server'
+    @mock.patch('enable.init_plugins')
+    def test_basic(self, init_plugins_mock):
+        plugindir = 'test/plugindir'
+        server = Mock()
+        server.config = {'pluginpath': plugindir}
         ret = on_message({"text": u"!enable help,enable"}, server)
         assert ret == "enabling plugins: help,enable"
-        reinit_plugins_mock.assert_called_with(['help','enable'], server)
+        init_plugins_mock.assert_called_with(plugindir, ['help','enable'])
 
-    @mock.patch('enable.reinit_plugins')
-    def test_star(self, reinit_plugins_mock):
-        server = 'fake_server'
+    @mock.patch('enable.init_plugins')
+    def test_star(self, init_plugins_mock):
+        plugindir = 'test/plugindir'
+        server = Mock()
+        server.config = {'pluginpath': plugindir}
         ret = on_message({"text": u"!enable *"}, server)
         assert ret == "enabling all plugins"
-        reinit_plugins_mock.assert_called_with(None, server)
+        init_plugins_mock.assert_called_with(plugindir, None)


### PR DESCRIPTION
This version of the "enable" plugin has just a one-line change to the upstream.  The other changes are encapulated in the plugin and test file.  This diff shows the net changes to implement the enable plugin:  https://github.com/davidchaiken/limbo/compare/dd81c18de501c60e232d42e86b7904a84998ae55...chaiken-wip
