### PR TITLE
Replaced AWS keys in environment with Task Role for limbo containers.

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -58,7 +58,9 @@ case "$1" in
     bin/ecr_push.sh
     docker-compose --file cmds.yml run \
       ecs-cli compose --file docker-compose.yml --region us-east-1 --cluster limbo \
-        --project-name $BOTNAME-$TYPE service up
+        --project-name $BOTNAME-$TYPE \
+        --task-role-arn arn:aws:iam::560921689673:role/LimboTaskRole \
+        service up
     ;;
 
   stop)
@@ -73,7 +75,9 @@ case "$1" in
       bin/ecr_push.sh
       docker-compose --file cmds.yml run \
         ecs-cli compose --file docker-compose.yml --region us-east-1 --cluster limbo \
-          --project-name $BOTNAME-$TYPE service up
+        --project-name $BOTNAME-$TYPE \
+        --task-role-arn arn:aws:iam::560921689673:role/LimboTaskRole \
+        service up
     else
       echo "Service not running, so not pushing an update."
     fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,6 @@ version: "2"
 services:
   limbo:
     environment:
-      AWS_ACCESS_KEY_ID:
-      AWS_SECRET_ACCESS_KEY:
       LIMBO_NEEDMENTION:
       LIMBO_CLOUDWATCH:
       SLACK_TOKEN:


### PR DESCRIPTION
Closes #22.

Before merging, we should think through how to present this to students. It might be better to leave this unmerged going into the class. During the lecture on security, we can show how the AWS keys as well as the Slack keys have been compromised. We can then walk them through the IAM "role" mechanism and explain why it was invented to solve this problem. We can then merge this patch in to fix the AWS/Bootstrapping problem, and ask the students to come up with a means of getting SLACK_TOKEN from S3.

(This is a rebase of PR #29, which I've closed in favor of this one.)