### PR TITLE
windows support for 6.S188

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,4 @@ slask.egg-info/
 .python-version
 .cache
 *~
-local-env
+windows-env

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ slask.egg-info/
 .python-version
 .cache
 *~
+local-env

--- a/Makefile.windows
+++ b/Makefile.windows
@@ -1,0 +1,78 @@
+# ACCT_NAME := $(shell git remote get-url origin | sed 's|.*[:/]\([^:/]*\)/[^/]*$$|\1|')
+# export SERVICE_NAME ?= $(ACCT_NAME)
+export SERVICE_NAME = amirfarhat
+
+.PHONY: testall
+testall: requirements
+	tox
+
+# to run a single file, with debugger support:
+# pytest -s test/test_plugins/test_image.py
+.PHONY: test
+test: install
+	LANG=en_US.UTF-8 pytest --cov=limbo --cov-report term-missing test
+
+.PHONY: clean
+clean:
+	rm -rf build dist limbo.egg-info
+
+.PHONY: run
+run: install
+	bin/limbo
+
+.PHONY: repl
+repl: install
+	bin/limbo -t
+
+.PHONY: requirements
+requirements:
+	pip install -r requirements.txt
+
+.PHONY: install
+install: requirements
+	python setup.py install
+	make clean
+
+.PHONY: publish
+publish:
+	pandoc -s -w rst README.md -o README.rst
+	python setup.py sdist upload
+	rm README.rst
+
+.PHONY: flake8
+flake8:
+	flake8 limbo test
+
+.PHONY: docker_build
+docker_build:
+	docker.exe build -f Dockerfile.test -t tim77/limbo-test .
+	docker.exe build --build-arg BASE=tim77/limbo-test -f Dockerfile.run -t tim77/limbo .
+
+.PHONY: docker_test
+docker_test:
+	docker.exe run -e LANG=en_US.UTF-8 tim77/limbo-test
+
+.PHONY: docker_run
+docker_run:
+	@# Suppress echo so slack token does not get shown
+	@docker.exe run -e SLACK_TOKEN=${SLACK_TOKEN} tim77/limbo
+
+.PHONY: docker_stop
+docker_stop:
+	docker.exe stop `docker.exe ps -q --filter ancestor=tim77/limbo --format="{{.ID}}"`
+
+.PHONY: ecr_repo
+ecr_repo:
+	docker-compose.exe -f cmds.yml run aws ecr create-repository --region us-east-1 --repository-name tim77/${SERVICE_NAME}
+
+.PHONY: travis_deploy
+travis_deploy:
+	bin/deploy.sh update
+
+.PHONY: ecs_start
+ecs_start:
+	bin/deploy.sh start
+
+.PHONY: ecs_stop
+ecs_stop:
+	bin/deploy.sh stop

--- a/Makefile.windows
+++ b/Makefile.windows
@@ -63,16 +63,16 @@ docker_stop:
 
 .PHONY: ecr_repo
 ecr_repo:
-	docker-compose.exe -f cmds.yml run aws ecr create-repository --region us-east-1 --repository-name tim77/${SERVICE_NAME}
+	docker-compose.exe -f cmds.windows.yml run aws ecr create-repository --region us-east-1 --repository-name tim77/${SERVICE_NAME}
 
 .PHONY: travis_deploy
 travis_deploy:
-	bin/deploy.sh update
+	bin/deploy.windows.sh update
 
 .PHONY: ecs_start
 ecs_start:
-	bin/deploy.sh start
+	bin/deploy.windows.sh start
 
 .PHONY: ecs_stop
 ecs_stop:
-	bin/deploy.sh stop
+	bin/deploy.windows.sh stop

--- a/bin/deploy.windows.sh
+++ b/bin/deploy.windows.sh
@@ -55,23 +55,23 @@ export LIMBO_CLOUDWATCH="Limbo&Botname=${SERVICE_NAME}&Env=${TYPE}"
 
 case "$1" in
   start)
-    bin/ecr_push.sh
-    docker-compose.exe --file cmds.yml run \
+    bin/ecr_push.windows.sh
+    docker-compose.exe --file cmds.windows.yml run \
       ecs-cli compose --file docker-compose.yml --region us-east-1 --cluster limbo \
         --project-name $SERVICE_NAME-$TYPE service up
     ;;
 
   stop)
-    docker-compose.exe --file cmds.yml run \
+    docker-compose.exe --file cmds.windows.yml run \
       ecs-cli compose --file docker-compose.yml --region us-east-1 --cluster limbo \
         --project-name $SERVICE_NAME-$TYPE service rm
     ;;
 
   update)
-    if (docker-compose.exe --file cmds.yml run ecs-cli ps --region us-east-1 --cluster limbo \
+    if (docker-compose.exe --file cmds.windows.yml run ecs-cli ps --region us-east-1 --cluster limbo \
          | grep RUNNING | grep $SERVICE_NAME); then
-      bin/ecr_push.sh
-      docker-compose.exe --file cmds.yml run \
+      bin/ecr_push.windows.sh
+      docker-compose.exe --file cmds.windows.yml run \
         ecs-cli compose --file docker-compose.yml --region us-east-1 --cluster limbo \
           --project-name $SERVICE_NAME-$TYPE service up
     else

--- a/bin/deploy.windows.sh
+++ b/bin/deploy.windows.sh
@@ -1,0 +1,85 @@
+#!/bin/bash -ve
+
+# Designed to be used from one's laptop and from Travis.  The
+# existence of TRAVIS_BRANCH is used to test where it's running.
+#
+# In both cases, the standard AWS_ environment variables need to be
+# defined to provide the AWS credentials for accessing ECR and ECS.
+# Also, SERVICE_NAME must be defined, which determines both the name of the
+# image in the Docker registry and the name of the service in ECS.
+#
+# When running on a laptop, `git symbolic-ref --short HEAD` is used in
+# place of TRAVIS_BRANCH to determine what branch is being built (so
+# it must be run from inside the repo).  Further, MASTER_SLACK_TOKEN
+# or WIP_SLACK_TOKEN must be defined (based on whether this is master
+# or WIP deploy).
+
+if [ $# -ne 1 ]; then
+  echo "Usage: $0 start|stop|update"
+  exit 1
+fi
+
+if [ "$TRAVIS_BRANCH" != "" ]; then
+  if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+    echo Skipping travis_deploy for pull request
+    exit 0
+  fi
+  export THE_BRANCH=$TRAVIS_BRANCH
+else
+  export THE_BRANCH=`git symbolic-ref --short HEAD`
+fi
+
+export TYPE=`expr "$THE_BRANCH" : ".*\(wip$\)"`
+if [ "$TYPE" != "wip" ]; then
+  export TYPE=`expr "$THE_BRANCH" : ".*\(master$\)"`
+  if [ "$TYPE" != "master" ]; then
+    echo Branch name does not end in "wip" or "master": skip deploy
+    exit 0
+  fi
+fi
+
+if [ "$SLACK_TOKEN" = "" ]; then
+  if [ "$TYPE" = "master" ]; then
+    export SLACK_TOKEN=$MASTER_SLACK_TOKEN
+  else
+    export SLACK_TOKEN=$WIP_SLACK_TOKEN
+  fi
+fi
+if [ "$SLACK_TOKEN" = "" ]; then
+  echo Missing ${TYPE}_SLACK_TOKEN
+  exit 1
+fi
+
+export IMAGE_THIS_BUILD=560921689673.dkr.ecr.us-east-1.amazonaws.com/tim77/$SERVICE_NAME:$TYPE
+export LIMBO_CLOUDWATCH="Limbo&Botname=${SERVICE_NAME}&Env=${TYPE}"
+
+case "$1" in
+  start)
+    bin/ecr_push.sh
+    docker-compose.exe --file cmds.yml run \
+      ecs-cli compose --file docker-compose.yml --region us-east-1 --cluster limbo \
+        --project-name $SERVICE_NAME-$TYPE service up
+    ;;
+
+  stop)
+    docker-compose.exe --file cmds.yml run \
+      ecs-cli compose --file docker-compose.yml --region us-east-1 --cluster limbo \
+        --project-name $SERVICE_NAME-$TYPE service rm
+    ;;
+
+  update)
+    if (docker-compose.exe --file cmds.yml run ecs-cli ps --region us-east-1 --cluster limbo \
+         | grep RUNNING | grep $SERVICE_NAME); then
+      bin/ecr_push.sh
+      docker-compose.exe --file cmds.yml run \
+        ecs-cli compose --file docker-compose.yml --region us-east-1 --cluster limbo \
+          --project-name $SERVICE_NAME-$TYPE service up
+    else
+      echo "Service not running, so not pushing an update."
+    fi
+    ;;
+
+  *)
+    echo "Usage: $0 start|update|stop"
+    exit 1
+esac

--- a/bin/ecr_push.windows.sh
+++ b/bin/ecr_push.windows.sh
@@ -3,7 +3,7 @@
 ## The acrobatics here (ie, output to limbo-tmp, using sed to extract
 ## password) are work-arounds to both awscli and MacOS problems.
 
-docker-compose.exe -f cmds.yml run aws ecr get-login \
+docker-compose.exe -f cmds.windows.yml run aws ecr get-login \
                     --region us-east-1 --no-include-email > limbo-tmp
 
 cat limbo-tmp | sed 's/docker login -u AWS -p \([^ ]*\) .*/\1/' \

--- a/bin/ecr_push.windows.sh
+++ b/bin/ecr_push.windows.sh
@@ -1,0 +1,16 @@
+#!/bin/bash -ve
+
+## The acrobatics here (ie, output to limbo-tmp, using sed to extract
+## password) are work-arounds to both awscli and MacOS problems.
+
+docker-compose.exe -f cmds.yml run aws ecr get-login \
+                    --region us-east-1 --no-include-email > limbo-tmp
+
+cat limbo-tmp | sed 's/docker login -u AWS -p \([^ ]*\) .*/\1/' \
+ | docker.exe login -u AWS --password-stdin \
+              560921689673.dkr.ecr.us-east-1.amazonaws.com
+
+rm limbo-tmp
+
+docker.exe tag tim77/limbo:latest $IMAGE_THIS_BUILD
+docker.exe push $IMAGE_THIS_BUILD

--- a/cmds.windows.yml
+++ b/cmds.windows.yml
@@ -1,0 +1,15 @@
+# A docker-compose file that runs commands out of a known image
+# A windows-env file is required to run on Windows.
+
+version: "2"
+
+services:
+  aws:
+    env_file: windows-env
+    image: tim77/limbo-test
+    entrypoint: [ "/usr/local/bin/aws" ]
+
+  ecs-cli:
+    env_file: windows-env
+    image: tim77/limbo-test
+    entrypoint: /usr/local/bin/ecs-cli


### PR DESCRIPTION
@rstata 

This pull request encapsulates all of the changes that Amir and I needed to do to get his Windows 10 system (with Ubuntu 16.04 in the Windows Subsystem for Linux) work the labs for 6.S188.  I chose to take a safe path, which uses separate files for Windows so that we can be sure that the version for OS X/Linux/TravisCI still works.  Since this pull request has separate files, it should be safe for you to merge.  (Of course, I'd appreciate it if you would look at the changes to judge this assertion for yourself.)

We created this alias in Amir's WSL .bashrc file to make it easier for him to run the the build:
```
alias mw='make -f Makefile.windows'
```

After this week, we can figure out a more clever way to integrate all of the platforms into one set of Makefiles.
