### PR TITLE
Makefile: added docker_debug target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,11 @@ docker_run:
 	@# Suppress echo so slack token does not get shown
 	@docker run -e SLACK_TOKEN=${SLACK_TOKEN} tim77/limbo
 
+.PHONY: docker_debug
+docker_debug:
+	@# Note: This command is insecure, because it emits SLACK_TOKEN to the terminal.
+	docker run -e SLACK_TOKEN=${SLACK_TOKEN} -e LIMBO_LOGLEVEL=DEBUG tim77/limbo
+
 .PHONY: docker_stop
 docker_stop:
 	docker stop `docker ps -q --filter ancestor=tim77/limbo --format="{{.ID}}"`


### PR DESCRIPTION
The docker_debug target sets limbo's logger to debug level and emits the log to the terminal.  This new Makefile target is insecure (and should only be used locally), because it emits the SLACK_TOKEN to the terminal. See issue #43.
